### PR TITLE
Fix NaN in Report; Remove alitude

### DIFF
--- a/src/components/photo.tsx
+++ b/src/components/photo.tsx
@@ -18,7 +18,7 @@ interface PhotoProps {
 
 /**
  * A component that displays a photo, timestamp, geolocation, label, and description
- * 
+ *
  * @param description Content (most commonly markdown text) used to describe the photo
  * @param label Label for the component
  * @param metadata Photo metadata including timestamp and geolocation
@@ -51,11 +51,11 @@ const Photo: FC<PhotoProps> = ({description, label, metadata, notes, photo, requ
                 }
                 <br />
                 Geolocation: {
-                  metadata?.geolocation?.latitude && metadata?.geolocation?.longitude ? 
+                  metadata?.geolocation?.latitude  && metadata?.geolocation?.latitude?.deg.toString() !== 'NaN' &&
+                  metadata?.geolocation?.longitude && metadata?.geolocation?.longitude?.deg.toString() !== 'NaN' ?
                   <span><GpsCoordStr {...metadata.geolocation.latitude} />  <GpsCoordStr {...metadata.geolocation.longitude} /></span> :
                   <span>Missing</span>
                 }
-                { metadata?.altitude && <><br /><span>Altitude: {metadata.altitude} meters</span></> }
               </small>
             </>
           ) : required && (
@@ -63,7 +63,7 @@ const Photo: FC<PhotoProps> = ({description, label, metadata, notes, photo, requ
           )
         }
         </Card.Body>
-        {notes && 
+        {notes &&
           <Card.Footer>{notes}</Card.Footer>}
       </Card>
     </>

--- a/src/components/photo_input.tsx
+++ b/src/components/photo_input.tsx
@@ -17,15 +17,15 @@ interface PhotoInputProps {
   upsertPhoto: (file: Blob) => void,
 }
 
-// TODO: Determine whether or not the useEffect() method is needed. 
-// We don't seem to need a separate camera button on an Android phone. 
+// TODO: Determine whether or not the useEffect() method is needed.
+// We don't seem to need a separate camera button on an Android phone.
 // However, we may need to request access to the camera
 // before it can me used. Then clean up the corresponding code that is currently
 // commented out.
 
 /**
  * Component for photo input
- * 
+ *
  * @param children Content (most commonly markdown text) describing the photo requirement
  * @param label Label for the photo requirement
  * @param metadata Abreviated photo metadata including timestamp and geolocation
@@ -111,11 +111,10 @@ const PhotoInput: FC<PhotoInputProps> = ({children, label, metadata, photo, upse
                 <br />
                 Geolocation: {
                   metadata?.geolocation?.latitude  && metadata?.geolocation?.latitude?.deg.toString() !== 'NaN' &&
-                  metadata?.geolocation?.longitude && metadata?.geolocation?.longitude?.deg.toString() !== 'NaN' ? 
+                  metadata?.geolocation?.longitude && metadata?.geolocation?.longitude?.deg.toString() !== 'NaN' ?
                   <span><GpsCoordStr {...metadata.geolocation.latitude} />  <GpsCoordStr {...metadata.geolocation.longitude} /></span> :
                   <span>Missing</span>
                 }
-                { metadata?.geolocation?.altitude && <><br /><span>Altitude: {metadata.geolocation.altitude.toString()} m</span></> }
               </small>
             </>
           )}


### PR DESCRIPTION
This applies Rae's fix for Nan in PhotoInput to Photo as well.
It also removes altitude from both PhotoInput and Photo.  The altitude was mostly a test to see if we could include altitude and was not project requirement.  Moreover, it could potentially suffer from the NaN issue, so I removed it until we can make it more robust.