### PR TITLE
More typescript error fixes

### DIFF
--- a/src/components/json_store_view.tsx
+++ b/src/components/json_store_view.tsx
@@ -17,9 +17,9 @@ interface JsonStoreViewProps {
  * 
  * @param dbName - The database name associated with an MDX template
  */
-const JsonStoreView: FC<JsonStoreViewProps> = ({dbName}: JsonStoreViewProps) => {
+const JsonStoreView: FC<JsonStoreViewProps> = ({dbName}) => {
   const {docId} = useParams();
-  return docId && (
+  return docId? (
     <StoreProvider dbName={dbName} docId={docId}>
       <StoreContext.Consumer>
         {({ attachments, doc }) => {
@@ -35,7 +35,8 @@ const JsonStoreView: FC<JsonStoreViewProps> = ({dbName}: JsonStoreViewProps) => 
         }}
       </StoreContext.Consumer>
     </StoreProvider>
-)}
+  ) : null
+}
 
 
 export default JsonStoreView

--- a/src/components/photo.tsx
+++ b/src/components/photo.tsx
@@ -11,7 +11,6 @@ interface PhotoProps {
   id: string,
   label: string,
   metadata: PhotoMetadata,
-  notes: string,
   photo: Blob | undefined,
   required: boolean,
 }
@@ -28,9 +27,9 @@ interface PhotoProps {
  * photo attachement in the data store with the given id. When set, the Photo component
  * will always show and the Photo component will indicate when the photo is missing.
  */
-const Photo: FC<PhotoProps> = ({description, label, metadata, notes, photo, required}) => {
+const Photo: FC<PhotoProps> = ({description, label, metadata, photo, required}) => {
 
-  return (photo || required) && (
+  return (photo || required)? (
     <>
       <Card style={{breakInside: 'avoid-page', marginBottom: '1rem'}}>
         <Card.Body>
@@ -63,11 +62,9 @@ const Photo: FC<PhotoProps> = ({description, label, metadata, notes, photo, requ
           )
         }
         </Card.Body>
-        {notes &&
-          <Card.Footer>{notes}</Card.Footer>}
       </Card>
     </>
-  );
+  ) : null;
 };
 
 export default Photo

--- a/src/components/photo_input.tsx
+++ b/src/components/photo_input.tsx
@@ -11,7 +11,6 @@ import PhotoMetaData from '../types/photo_metadata.type'
 
 interface PhotoInputProps {
   children: React.ReactNode,
-  id: string,
   label: string,
   metadata: PhotoMetaData,
   photo: Blob | undefined,

--- a/src/components/photo_input_wrapper.tsx
+++ b/src/components/photo_input_wrapper.tsx
@@ -39,7 +39,7 @@ const PhotoInputWrapper: FC<PhotoInputWrapperProps> = ({children, id, label}) =>
         }
 
         return (
-          <PhotoInput children={children} id={id} label={label}
+          <PhotoInput children={children} label={label}
             metadata={(attachments[id]?.metadata as unknown) as PhotoMetadata}
             photo={attachments[id]?.blob} upsertPhoto={upsertPhoto}
              />

--- a/src/components/photo_wrapper.tsx
+++ b/src/components/photo_wrapper.tsx
@@ -31,7 +31,7 @@ const PhotoWrapper: FC<PhotoWrapperProps> = ({children, id, label, required}) =>
       {({attachments, doc}) => {
         return (
           <Photo description={children} id={id} label={label}
-            metadata={(attachments[id]?.metadata as unknown) as PhotoMetadata} notes={doc.photos?.[id]?.notes }
+            metadata={(attachments[id]?.metadata as unknown) as PhotoMetadata}
             photo={attachments[id]?.blob} required={required}
           />
         )

--- a/src/components/store.tsx
+++ b/src/components/store.tsx
@@ -48,7 +48,7 @@ export const StoreProvider: FC<StoreProviderProps> = ({ children, dbName, docId 
   const [attachments, setAttachments] = useState<Record<string, Attachment>>({});
   const [db, setDB] = useState();
   // The doc state could be anything that is JSON-compatible
-  const [doc, setDoc] = useState();
+  const [doc, setDoc] = useState({});
 
   /**
    * Updates component state based on a database document change
@@ -61,7 +61,7 @@ export const StoreProvider: FC<StoreProviderProps> = ({ children, dbName, docId 
     revisionRef.current = dbDoc._rev
 
     // Set doc state
-    const newDoc = {...dbDoc}
+    const newDoc: Partial<typeof dbDoc> = {...dbDoc}
     delete newDoc._attachments
     delete newDoc._id
     delete newDoc._rev

--- a/src/components/store.tsx
+++ b/src/components/store.tsx
@@ -8,7 +8,6 @@ import {getPhotoMetadata} from '../utilities/photo_utils'
 import { isEmptyBindingElement } from 'typescript';
 import Attachment from '../types/attachment.type'
 import type {Objectish, AnyObject, AnyArray, NonEmptyArray} from '../types/misc_types.type'
-import { AsyncResource } from 'async_hooks';
 
 PouchDB.plugin(PouchDBUpsert)
 
@@ -17,14 +16,14 @@ interface UpsertAttachment {
 }
 
 interface UpsertData {
-  (path: string, data: any): void;
+  (pathStr: string, data: any): void;
 }
 
 export const StoreContext = React.createContext({
   attachments:  {} as Record<string, {blob: Blob, metadata: Record<string, JSONValue>}>,
   doc: {} as JSONValue,
-  upsertAttachment: (blob: Blob, id: any) => {},
-  upsertData: (path: string, data: any) => {},
+  upsertAttachment: ((blob: Blob, id: any) => {}) as UpsertAttachment,
+  upsertData: ((pathStr: string, data: any) => {}) as UpsertData,
 });
 
 
@@ -46,7 +45,7 @@ export const StoreProvider: FC<StoreProviderProps> = ({ children, dbName, docId 
   const revisionRef = useRef<string>();
   // The attachments state will have the form: {[att_id]: {blob, digest, metadata}, ...}
   const [attachments, setAttachments] = useState<Record<string, Attachment>>({});
-  const [db, setDB] = useState();
+  const [db, setDB] = useState<PouchDB.Database>();
   // The doc state could be anything that is JSON-compatible
   const [doc, setDoc] = useState({});
 
@@ -78,18 +77,23 @@ export const StoreProvider: FC<StoreProviderProps> = ({ children, dbName, docId 
         const docAttachment = dbDocAttachments[attachmentId]
         // digest is a hash of the attachment, so a different digest indicates a modified attachment
         const digest = docAttachment.digest
-        if (!attachments.hasOwnProperty(attachmentId) || attachments[attachmentId].digest != digest) {
+        if (digest && (!attachments.hasOwnProperty(attachmentId) || attachments[attachmentId].digest != digest)) {
           console.log('New attachment')
           // This is a new or modified attachment, so build a new attachment for state
-          const blob = (await db.getAttachment(docId, attachmentId) as unknown) as Blob
-
-          newAttachments = {
-            ...newAttachments,
-            [attachmentId]: {
-              blob,
-              digest,
-              metadata: blob.type === 'image/jpeg' ? await getPhotoMetadata(blob) : {}
+          const blobOrBuffer = await db.getAttachment(docId, attachmentId)
+          if (blobOrBuffer instanceof Blob) {
+            const blob = blobOrBuffer
+            const metadata = blob.type === 'image/jpeg' ? await getPhotoMetadata(blob) : {}
+            newAttachments = {
+              ...newAttachments,
+              [attachmentId]: {
+                blob,
+                digest,
+                metadata,
+              }
             }
+          } else {
+            throw new Error('Attachment must be a Blob')
           }
         } 
       }
@@ -122,6 +126,8 @@ export const StoreProvider: FC<StoreProviderProps> = ({ children, dbName, docId 
 
       // Initialize the DB document as needed
       try {
+        // It looks like the type def for putIfNotExists does not match its implementation
+        // TODO: Check this over carefully
         const result = await db.putIfNotExists(docId, {})
         revisionRef.current = result.rev
       } catch(err) {
@@ -146,7 +152,7 @@ export const StoreProvider: FC<StoreProviderProps> = ({ children, dbName, docId 
         console.log('Database changed')
         console.log('_rev:', change.doc?._rev)
         console.log('current:', revisionRef.current)
-        if (change.doc?._rev !== revisionRef.current) {
+        if (change.doc && change.doc._rev !== revisionRef.current) {
           // The change must have originated from outside this component, so update component state
           console.log('processing DB change')
           processDBDocChange(db, change.doc)
@@ -177,23 +183,25 @@ export const StoreProvider: FC<StoreProviderProps> = ({ children, dbName, docId 
    * The given path is gauranteed to exist after the update/insertion.
    * This function is typically passed to an input wrapper component via the StoreContext.Provider value
    * 
-   * @param path An array such as ["foo", "bar", "2", "biz"] that represents a path into the doc state
+   * @param pathStr A string path such as "foo.bar[2].biz" that represents a path into the doc state
    * @param data The data that is to be updated/inserted at the path location in the doc state
    */
-  const upsertData: UpsertData = (path, data) => {
+  const upsertData = (pathStr: string, data: any) => {
     // Update doc state
-    const newDoc = immutableUpsert(doc, toPath(path), data)
+    const newDoc = immutableUpsert(doc, toPath(pathStr) as NonEmptyArray<string>, data)
     setDoc(newDoc);
 
 
     // Persist the doc
-    db.upsert(docId, function upsertFn(dbDoc: any) {
-      return {...dbDoc, ...newDoc};
-    }).then(function (res) {
-      revisionRef.current = res.rev
-    }).catch(function (err : Error) {
-      console.error('upsert error:', err)
-    });
+    if (db) {
+      db.upsert(docId, function upsertFn(dbDoc: any) {
+        return {...dbDoc, ...newDoc};
+      }).then(function (res) {
+        revisionRef.current = res.rev
+      }).catch(function (err : Error) {
+        console.error('upsert error:', err)
+      })
+    }
 
   };
 
@@ -204,7 +212,7 @@ export const StoreProvider: FC<StoreProviderProps> = ({ children, dbName, docId 
    */
   const upsertAttachment: UpsertAttachment = async (blob, id: string) => {
     // Create the metadata for the blob
-    const metadata = (
+    const metadata: Attachment["metadata"] = (
       blob.type === "image/jpeg" ? await getPhotoMetadata(blob) :
       {}
     )
@@ -220,22 +228,28 @@ export const StoreProvider: FC<StoreProviderProps> = ({ children, dbName, docId 
     setAttachments(newAttachments)
 
     // Persist the blob
-    const upsertBlobDB = async (rev) => {
+    const upsertBlobDB = async (rev: string): Promise<PouchDB.Core.Response | null> => {
       let result = null
-      try {
-        result = await db.putAttachment(docId, id, rev, blob, blob.type)
-      } catch(err) {
-        // Try again with the latest rev value
-        const doc = await db.get(docId)
-        result = await upsertBlobDB(doc._rev)
-      } finally {
-        revisionRef.current = result.rev
-      }
+      if (db) {
+        try {
+          result = await db.putAttachment(docId, id, rev, blob, blob.type)
+        } catch(err) {
+          // Try again with the latest rev value
+          const doc = await db.get(docId)
+          result = await upsertBlobDB(doc._rev)
+        } finally {
+          if (result) {
+            revisionRef.current = result.rev
+          }
+        }
 
+      }
       return result
     }
 
-    upsertBlobDB(revisionRef.current)
+    if (revisionRef.current) {
+      upsertBlobDB(revisionRef.current)
+    }
   };
 
   return (

--- a/src/types/attachment.type.ts
+++ b/src/types/attachment.type.ts
@@ -4,8 +4,8 @@ import JSONValue from './json_value.type'
 
 interface Attachment  {
   blob: Blob,
-  digest: string,
-  metadata: Record<string, JSONValue>,
+  digest?: string,
+  metadata: Record<string, any>,
 }
 
 export default Attachment

--- a/src/utilities/photo_utils.tsx
+++ b/src/utilities/photo_utils.tsx
@@ -1,5 +1,7 @@
 import EXIF from 'exif-js'
 
+import Attachment from '../types/attachment.type'
+
 /**
  * Extracts the timestamp and geolocation data from a JPEG photo's
  * metadata
@@ -18,7 +20,7 @@ import EXIF from 'exif-js'
  *  timestamp
  * }
  */
-export async function getPhotoMetadata(photo: Blob) {
+export async function getPhotoMetadata(photo: Blob): Promise<Attachment["metadata"]> {
 
   return new Promise((resolve) => {
     EXIF.getData(photo, function() {


### PR DESCRIPTION
@RaeChen07 Please check this over and merge it into your 15-resolve-typescript-errors branch.

The two TS errors from store.tsx lines 131 and 132 seem to be caused by the `PouchDBUpsert` module messing up the Typescript definition of its `putIfNotExists` method.  We should all discuss how best to handle that.

There is just one other TS error in store.tsx and two in photo_utils.tsx